### PR TITLE
Upgrade to sdkbase2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/kbase:sdkbase.latest
+FROM kbase/kbase:sdkbase2.latest
 MAINTAINER KBase Developer
 # -----------------------------------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# GenomeProteomeComparison release notes
+=========================================
+
+0.0.7
+-----
+* Upgrade to sdkbase2
+

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     java
 
 module-version:
-    0.0.6
+    0.0.7
 
 owners:
     [rsutormin]


### PR DESCRIPTION
Created fir PTV-1291
The tests fail because the datasets are out of date (old genome format). Even after updating the test data, there were test problems so I left the data alone.